### PR TITLE
Fix: Allow filtering field values to empty `string` or `null`

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -740,7 +740,7 @@ class Form extends Child implements FormInterface, \ArrayAccess, \Countable, \It
         }
 
         if (($field instanceof AbstractElement) && !($field instanceof Checkbox) &&
-            !($field instanceof Radio) && ($realValue !== null) && ($realValue != '')) {
+            !($field instanceof Radio)) {
             $field->setValue($realValue);
         }
 


### PR DESCRIPTION
This pull request

- [x] asserts hat field values can be filtered to empty `string` or `null`
- [x] allows filtering field values to an empty `string` or `null`