### PR TITLE
Fix: Allow setting value of `Element\Textarea` to `null`

### DIFF
--- a/src/Element/Textarea.php
+++ b/src/Element/Textarea.php
@@ -96,6 +96,13 @@ class Textarea extends AbstractElement
         return parent::setReadonly($readonly);
     }
 
+    public function setNodeValue(?string $value): Textarea
+    {
+        $this->nodeValue = $value;
+
+        return $this;
+    }
+
     /**
      * Set the value of the form textarea element object
      *

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -169,6 +169,23 @@ class InputTest extends TestCase
         $this->assertInstanceOf('Pop\Form\Element\Input\Text', $input);
     }
 
+    public function testValueIsNullByDefault()
+    {
+        $input = new Input\Text('my_text');
+
+        $this->assertNull($input->getValue());
+    }
+
+    public function testCanSetValueToNull()
+    {
+        $input = new Input\Text('my_text');
+
+        $input->setValue('foo');
+        $input->setValue(null);
+
+        $this->assertNull($input->getValue());
+    }
+
     public function testUrl()
     {
         $input = new Input\Url('my_url');

--- a/tests/TextareaTest.php
+++ b/tests/TextareaTest.php
@@ -21,6 +21,23 @@ class TextareaTest extends TestCase
         $this->assertTrue(empty($textarea->getValue()));
     }
 
+    public function testValueIsNullByDefault()
+    {
+        $textarea = new Textarea('my_textarea');
+
+        $this->assertNull($textarea->getValue());
+    }
+
+    public function testCanSetValueToNull()
+    {
+        $textarea = new Textarea('my_textarea');
+
+        $textarea->setValue('foo');
+        $textarea->setValue(null);
+
+        $this->assertNull($textarea->getValue());
+    }
+
     public function testValidate()
     {
         $textarea = new Textarea('my_textarea', 'Type something', '    ');


### PR DESCRIPTION
This pull request

- [x] asserts that the default values of `Element\Text` and `Element\Textarea` are `null` and that they can be set to `null`
- [x] allows setting the value of `Element\Textarea` to `null`